### PR TITLE
Support for fetching overdue invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `whmcs_get_invoices` - Add 'Overdue' status filter option
+
 ## [1.2.1] - 2026-03-11
 
 ### Added

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -215,7 +215,7 @@ Get invoices with optional filtering.
 | `limitstart` | number | No | Starting offset |
 | `limitnum` | number | No | Number of results |
 | `userid` | number | No | Filter by client ID |
-| `status` | string | No | Filter by status: `Paid`, `Unpaid`, `Cancelled`, `Refunded`, `Collections`, `Draft` |
+| `status` | string | No | Filter by status: `Paid`, `Unpaid`, `Cancelled`, `Refunded`, `Collections`, `Draft`, `Overdue` |
 | `orderby` | string | No | Field to order by |
 | `order` | string | No | Sort order: `asc` or `desc` |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ server.registerTool(
             limitstart: z.number().optional().describe('Starting offset'),
             limitnum: z.number().optional().describe('Number of results'),
             userid: z.number().optional().describe('Filter by client ID'),
-            status: z.enum(['Paid', 'Unpaid', 'Cancelled', 'Refunded', 'Collections', 'Draft']).optional().describe('Filter by status'),
+            status: z.enum(['Paid', 'Unpaid', 'Cancelled', 'Refunded', 'Collections', 'Draft', 'Overdue']).optional().describe('Filter by status'),
             orderby: z.string().optional().describe('Field to order by'),
             order: z.enum(['asc', 'desc']).optional().describe('Sort order'),
         },

--- a/src/whmcs-client.ts
+++ b/src/whmcs-client.ts
@@ -411,7 +411,7 @@ export class WhmcsApiClient {
         limitstart?: number;
         limitnum?: number;
         userid?: number;
-        status?: 'Paid' | 'Unpaid' | 'Cancelled' | 'Refunded' | 'Collections' | 'Draft';
+        status?: 'Paid' | 'Unpaid' | 'Cancelled' | 'Refunded' | 'Collections' | 'Draft' | 'Overdue';
         orderby?: string;
         order?: 'asc' | 'desc';
     } = {}) {


### PR DESCRIPTION
## Description

Adds support for fetching Overdue status invoices with GetInvoices.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issue


## Changes Made
- Add 'Overdue' to the supported list of status parameters in GetInvoices. This status is documented in https://developers.whmcs.com/api-reference/getinvoices/ : "status - Find invoices for a specific status. Standard Invoice statuses plus Overdue"

## New Tools Added (if applicable)

## Testing
- [X] I have tested these changes locally
- [X] I have verified the connection to WHMCS works
- [X] I have added/updated documentation as needed

## Checklist
- [X] My code follows the project's coding standards
- [X] I have updated the CHANGELOG.md
- [X] I have updated the API_REFERENCE.md (if adding tools)
- [ ] I have added TypeScript types for all new functions
- [ ] I have used Zod schemas for input validation
