### PR TITLE
feat: add Streamable HTTP transport for remote hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,17 @@ WHMCS_API_SECRET=
 # API Access Key (set in WHMCS Admin > Setup > General Settings > Security)
 # Leave empty if not configured
 WHMCS_ACCESS_KEY=
+
+# ===========================================
+# OPTIONAL: HTTP Transport (docker / remote access)
+# ===========================================
+# Host port to expose the MCP HTTP endpoint on (container always listens on 3000)
+MCP_HTTP_PORT=3000
+
+# Bearer token required from clients. Leave empty to disable auth.
+# STRONGLY recommended when exposing the server beyond localhost.
+MCP_AUTH_TOKEN=
+
+# Comma-separated Host header allowlist (DNS-rebinding protection)
+# Example: mcp.example.com,localhost
+MCP_ALLOWED_HOSTS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm install
 
 # Copy source code
 COPY tsconfig.json ./
@@ -29,7 +29,7 @@ RUN addgroup -g 1001 -S mcpuser && \
 COPY package*.json ./
 
 # Install production dependencies only
-RUN npm ci --only=production && \
+RUN npm install --omit=dev && \
     npm cache clean --force
 
 # Copy built files from builder
@@ -46,10 +46,17 @@ ENV WHMCS_API_URL=""
 ENV WHMCS_API_IDENTIFIER=""
 ENV WHMCS_API_SECRET=""
 ENV WHMCS_ACCESS_KEY=""
+ENV MCP_HTTP_PORT="3000"
+ENV MCP_HTTP_HOST="0.0.0.0"
+ENV MCP_AUTH_TOKEN=""
+ENV MCP_ALLOWED_HOSTS=""
 
-# Health check - verify node process is running
+# HTTP transport listens on this port
+EXPOSE 3000
+
+# Health check - hit the HTTP health endpoint
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD node -e "console.log('healthy')" || exit 1
+    CMD node -e "fetch('http://127.0.0.1:'+(process.env.MCP_HTTP_PORT||3000)+'/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
-# Run the MCP server
-CMD ["node", "dist/index.js"]
+# Run the MCP server over HTTP
+CMD ["node", "dist/http.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   whmcs-mcp-server:
     build:
@@ -7,19 +5,23 @@ services:
       dockerfile: Dockerfile
     container_name: whmcs-mcp-server
     restart: unless-stopped
+    ports:
+      - "${MCP_HTTP_PORT:-3000}:3000"
     environment:
       - WHMCS_API_URL=${WHMCS_API_URL}
       - WHMCS_API_IDENTIFIER=${WHMCS_API_IDENTIFIER}
       - WHMCS_API_SECRET=${WHMCS_API_SECRET}
       - WHMCS_ACCESS_KEY=${WHMCS_ACCESS_KEY:-}
-    # For stdio-based MCP servers, we need stdin/stdout
-    stdin_open: true
-    tty: true
-    # Optional: Add network restrictions for security
-    # networks:
-    #   - mcp-network
-
-# Optional: Define custom network
-# networks:
-#   mcp-network:
-#     driver: bridge
+      # HTTP transport config
+      - MCP_HTTP_PORT=3000
+      - MCP_HTTP_HOST=0.0.0.0
+      # Set a token to require `Authorization: Bearer <token>` from clients
+      - MCP_AUTH_TOKEN=${MCP_AUTH_TOKEN:-}
+      # Comma-separated Host allowlist for DNS-rebinding protection (e.g. mcp.example.com)
+      - MCP_ALLOWED_HOSTS=${MCP_ALLOWED_HOSTS:-}
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      start_period: 5s
+      retries: 3

--- a/package.json
+++ b/package.json
@@ -8,12 +8,15 @@
     "scarecr0w12"
   ],
   "bin": {
-    "whmcs-mcp-server": "./dist/index.js"
+    "whmcs-mcp-server": "./dist/index.js",
+    "whmcs-mcp-server-http": "./dist/http.js"
   },
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
+    "start:http": "node dist/http.js",
     "dev": "tsx src/index.ts",
+    "dev:http": "tsx src/http.ts",
     "watch": "tsc --watch",
     "test": "tsx src/test.ts",
     "lint": "tsc --noEmit",
@@ -57,9 +60,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "dotenv": "^17.2.3",
+    "express": "^5.1.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * WHMCS MCP Server - Streamable HTTP transport
+ *
+ * Runs the WHMCS MCP server over HTTP so it can be hosted on a server and
+ * accessed remotely by MCP clients. Uses the MCP Streamable HTTP transport
+ * with per-session transports.
+ *
+ * Env vars:
+ *   MCP_HTTP_PORT   - Port to listen on (default 3000)
+ *   MCP_HTTP_HOST   - Host to bind (default 0.0.0.0)
+ *   MCP_AUTH_TOKEN  - Optional. If set, clients must send
+ *                     `Authorization: Bearer <token>`.
+ *   MCP_ALLOWED_HOSTS - Optional comma-separated Host header allowlist
+ *                       for DNS-rebinding protection (e.g. mcp.example.com).
+ */
+
+import 'dotenv/config';
+import { randomUUID } from 'node:crypto';
+import express, { Request, Response } from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createServer, validateConfig } from './index.js';
+
+const PORT = parseInt(process.env.MCP_HTTP_PORT || '3000', 10);
+const HOST = process.env.MCP_HTTP_HOST || '0.0.0.0';
+const AUTH_TOKEN = process.env.MCP_AUTH_TOKEN;
+const ALLOWED_HOSTS = (process.env.MCP_ALLOWED_HOSTS || '')
+    .split(',')
+    .map((h) => h.trim())
+    .filter(Boolean);
+
+// Map of active sessions -> their transport.
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+function unauthorized(res: Response) {
+    res.status(401).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Unauthorized' },
+        id: null,
+    });
+}
+
+function checkAuth(req: Request, res: Response): boolean {
+    if (!AUTH_TOKEN) return true;
+    const header = req.headers.authorization || '';
+    const token = header.startsWith('Bearer ') ? header.slice(7) : '';
+    if (token !== AUTH_TOKEN) {
+        unauthorized(res);
+        return false;
+    }
+    return true;
+}
+
+const app = express();
+app.use(express.json({ limit: '4mb' }));
+
+// Simple health check for load balancers / uptime monitors.
+app.get('/health', (_req, res) => {
+    res.json({ status: 'ok', configured: validateConfig(), sessions: transports.size });
+});
+
+const handleSession = async (req: Request, res: Response) => {
+    if (!checkAuth(req, res)) return;
+
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    // Existing session: route to its transport.
+    if (sessionId && transports.has(sessionId)) {
+        await transports.get(sessionId)!.handleRequest(req, res, req.body);
+        return;
+    }
+
+    // New session: only valid on an initialize request.
+    if (!sessionId && isInitializeRequest(req.body)) {
+        const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            enableDnsRebindingProtection: ALLOWED_HOSTS.length > 0,
+            allowedHosts: ALLOWED_HOSTS.length > 0 ? ALLOWED_HOSTS : undefined,
+            onsessioninitialized: (id) => {
+                transports.set(id, transport);
+            },
+        });
+
+        transport.onclose = () => {
+            if (transport.sessionId) transports.delete(transport.sessionId);
+        };
+
+        const server = createServer();
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+        return;
+    }
+
+    if (sessionId) {
+        res.status(404).json({
+            jsonrpc: '2.0',
+            error: { code: -32001, message: 'Session not found' },
+            id: null,
+        });
+        return;
+    }
+
+    res.status(400).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Bad Request: no valid session ID' },
+        id: null,
+    });
+};
+
+// Streamable HTTP endpoint: POST for requests, GET for the SSE stream, DELETE to close.
+app.post('/mcp', handleSession);
+app.get('/mcp', handleSession);
+app.delete('/mcp', handleSession);
+
+function main() {
+    if (!validateConfig()) {
+        console.error('Warning: WHMCS configuration incomplete. Tools will not function until configured.');
+    }
+
+    app.listen(PORT, HOST, () => {
+        console.error(`WHMCS MCP Server started (HTTP) on http://${HOST}:${PORT}/mcp`);
+        if (AUTH_TOKEN) console.error('Bearer token auth: ENABLED');
+        else console.error('Bearer token auth: DISABLED (set MCP_AUTH_TOKEN to require a token)');
+    });
+}
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 import 'dotenv/config';
+import { pathToFileURL } from 'node:url';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import * as z from 'zod';
@@ -21,7 +22,7 @@ const config: WhmcsConfig = {
 };
 
 // Validate required configuration
-function validateConfig(): boolean {
+export function validateConfig(): boolean {
     if (!config.apiUrl || !config.apiIdentifier || !config.apiSecret) {
         console.error('Missing required WHMCS configuration. Please set the following environment variables:');
         console.error('  WHMCS_API_URL - The URL to your WHMCS installation (e.g., https://example.com/whmcs/)');
@@ -37,6 +38,7 @@ function validateConfig(): boolean {
 const whmcsClient = new WhmcsApiClient(config);
 
 // Create the MCP server
+export function createServer(): McpServer {
 const server = new McpServer({
     name: 'whmcs-mcp-server',
     version: '1.0.0',
@@ -1937,6 +1939,9 @@ server.registerResource(
     }
 );
 
+    return server;
+}
+
 // ========================================
 // START SERVER
 // ========================================
@@ -1947,12 +1952,20 @@ async function main() {
         console.error('Warning: WHMCS configuration incomplete. Tools will not function until configured.');
     }
 
+    const server = createServer();
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error('WHMCS MCP Server started');
+    console.error('WHMCS MCP Server started (stdio)');
 }
 
-main().catch((error) => {
-    console.error('Fatal error:', error);
-    process.exit(1);
-});
+// Only auto-start stdio transport when this file is the entry point
+// (not when imported by the HTTP server in http.ts).
+const isDirectRun =
+    process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+    main().catch((error) => {
+        console.error('Fatal error:', error);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
Run the MCP server over HTTP so it can be hosted on a server and accessed remotely by MCP clients, alongside the existing stdio transport.

- src/index.ts: wrap tool/resource registration in an exported createServer() factory; only auto-start stdio when index.js is the entry point so the HTTP server can import it without launching stdio. Export validateConfig.
- src/http.ts: Express + StreamableHTTPServerTransport with per-session transports, /mcp (POST/GET/DELETE) and /health endpoints, optional bearer auth (MCP_AUTH_TOKEN) and DNS-rebinding protection (MCP_ALLOWED_HOSTS).
- package.json: add express/@types/express, start:http & dev:http scripts, whmcs-mcp-server-http bin.
- Dockerfile: default CMD to HTTP entrypoint, EXPOSE 3000, HTTP env vars, HTTP-based healthcheck; npm ci -> npm install.
- docker-compose.yml: publish port 3000, HTTP env, healthcheck; drop stdio stdin_open/tty.
- .env.example: document HTTP transport env vars.

## Description
Brief description of changes made.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issue
Fixes #(issue number)

## Changes Made
- Change 1
- Change 2
- Change 3

## New Tools Added (if applicable)
| Tool Name | Description |
|-----------|-------------|
| `whmcs_example` | Brief description |

## Testing
- [ ] I have tested these changes locally
- [ ] I have verified the connection to WHMCS works
- [ ] I have added/updated documentation as needed

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have updated the CHANGELOG.md
- [ ] I have updated the API_REFERENCE.md (if adding tools)
- [ ] I have added TypeScript types for all new functions
- [ ] I have used Zod schemas for input validation
